### PR TITLE
Upgrade ubuntu, citra, and use Vulkan renderer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - nightly-2023-06-01
+          - nightly-2024-02-18
 
     runs-on: ubuntu-latest
     container: devkitpro/devkitarm
@@ -39,7 +39,7 @@ jobs:
       matrix:
         toolchain:
           # Oldest supported nightly
-          - nightly-2023-06-01
+          - nightly-2024-02-18
           - nightly
 
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}

--- a/run-tests/Dockerfile
+++ b/run-tests/Dockerfile
@@ -5,7 +5,7 @@ COPY ./docker/download_citra.sh /usr/local/bin/download_citra
 RUN apt-get update -y && apt-get install -y jq
 
 ARG CITRA_CHANNEL=nightly
-ARG CITRA_RELEASE=1995
+ARG CITRA_RELEASE=2098
 RUN download_citra ${CITRA_CHANNEL} ${CITRA_RELEASE}
 
 FROM devkitpro/devkitarm:latest as devkitarm
@@ -17,15 +17,18 @@ RUN cd /opt/devkitpro/examples/3ds/graphics/printing/hello-world && \
     make && \
     mv hello-world.3dsx /tmp/
 
-FROM ubuntu:latest
+FROM ubuntu:mantic
 
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     apt-get update -y && \
     apt-get install -y \
-        libswscale5 \
+        libavfilter9 \
+        libavformat60 \
+        libavutil58 \
         libsdl2-2.0-0 \
-        libavformat58 \
-        libavfilter7 \
+        libswscale7 \
+        mesa-vulkan-drivers \
+        vulkan-tools \
         xvfb
 
 COPY --from=devkitarm /opt/devkitpro /opt/devkitpro

--- a/run-tests/docker/sdl2-config.ini
+++ b/run-tests/docker/sdl2-config.ini
@@ -1,3 +1,8 @@
+# OpenGL renderer seems to crash so we force using vulkan:
+# https://github.com/rust3ds/test-runner/issues/16
+[Renderer]
+graphics_api = 2
+
 [Miscellaneous]
 log_filter = *:Info Debug.Emulated:Debug
 


### PR DESCRIPTION
Closes #16, hopefully! 

Planning to tag this as `v1.1.0` so we can see if it stops crashing in tests all the time